### PR TITLE
Remove resources filter for DLM IAM

### DIFF
--- a/ec2/infrastructure/backup.tf
+++ b/ec2/infrastructure/backup.tf
@@ -26,9 +26,7 @@ data "aws_iam_policy_document" "dlm_backup_abilities" {
       "ec2:DescribeSnapshots",
     ]
 
-    resources = [
-      aws_instance.madoc.arn
-    ]
+    resources = ["*"]
   }
 
   statement {


### PR DESCRIPTION
DLM uses tags for targetting which volumes are backed up so needs to query all volumes